### PR TITLE
Callback errors (#101)

### DIFF
--- a/Runtime/Components/CallbackComponents.cs
+++ b/Runtime/Components/CallbackComponents.cs
@@ -26,7 +26,12 @@ namespace PeachyTween {
     internal static void Invoke<T>(this EcsWorld world, int entity) where T : struct, ICallback {
       var callbackPool = world.GetPool<T>();
       if (callbackPool.Has(entity)) {
-        callbackPool.Get(entity).Callback();
+        try {
+          callbackPool.Get(entity).Callback();
+        } catch (Exception e) {
+          var error = new Exception($"Error in {typeof(T)} callback", e);
+          UnityEngine.Debug.LogError(error);
+        }
       }
     }
 

--- a/Runtime/Core.cs
+++ b/Runtime/Core.cs
@@ -441,14 +441,14 @@ namespace PeachyTween {
       AssertNotRunning();
       if (_groupFilters.TryGetValue(typeof(TGroup), out var filter)) {
         _runState.Set(filter, deltaTime);
-        _systems.Run();
+        Run();
       }
     }
 
     public static void ManualUpdate(int entity, float deltaTime) {
       AssertNotRunning();
       _runState.Set(entity, deltaTime);
-      _systems.Run();
+      Run();
     }
 
     public static void Sync(int entity) => ManualUpdate(entity, 0);

--- a/Tests/OnUpdateTest.cs
+++ b/Tests/OnUpdateTest.cs
@@ -1,5 +1,6 @@
-using UnityEngine;
 using NUnit.Framework;
+using System;
+using UnityEngine;
 
 namespace PeachyTween.Tests {
   public class OnUpdateTest : BaseTweenTest {
@@ -55,6 +56,27 @@ namespace PeachyTween.Tests {
 
       Assert.AreEqual(1, aCount, $"first {nameof(OnUpdate)} callback called");
       Assert.AreEqual(0, bCount, $"second {nameof(OnUpdate)} callback was not called");
+    }
+
+    [Test]
+    public void SyncOnUpdate() {
+      var caught = null as Exception;
+      var onUpdate = 0;
+      var tween = Peachy.Tween(0f, 1f, 1f, _ => {});
+
+      tween.OnUpdate(() => {
+        onUpdate++;
+        try {
+          tween.Sync();
+        } catch (Exception e) {
+          caught = e;
+        }
+      });
+
+      tween.ManualUpdate(0.5f);
+
+      Assert.AreEqual(1, onUpdate, $"{nameof(OnUpdate)} callback called");
+      Assert.True(caught is Exception, $"{nameof(Exception)} caught");
     }
   }
 }


### PR DESCRIPTION
Temporary (maybe?) solution to #101

This prevents callbacks from harming the ECS tween progress. Still leaves the issue Sync and Run operations, when called from callbacks, will cause errors. But this may be desirable to prevent endless loops e.g.:

```cs
tween.OnUpdate(() => tween.Sync()); // sync triggers an OnUpdate callback
```